### PR TITLE
MAR-6042. Fix transparent ebook event name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maddevs/mad-radiator",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "description": "Script for collect data from analytics and send to slack(webhook) and telegram",
   "keywords": [
     "radiator",

--- a/src/analytics/EbookDownloadsRepository.ts
+++ b/src/analytics/EbookDownloadsRepository.ts
@@ -51,7 +51,7 @@ export class EbookDownloadsRepository extends Repository {
             name: 'Mad Devs Engineering’s Handbook',
           })
         }
-        if(row.dimensionValues[0]?.value === 'submit_transparent_relationships_ebook_form') {
+        if(row.dimensionValues[0]?.value === 'submit_transparent_relationships_ebook_f') {
           acc.push({
               value: Number(row.metricValues[0].value),
               name: 'Transparent Relationships With Stakeholders',


### PR DESCRIPTION
1. [MAR-6042: Заменить в маркетинговом радиаторе название ивента для ебука transparent relationships.](https://maddevs.atlassian.net/browse/MAR-6042)
2. Commits:
[Fix transparent ebook event name.](https://github.com/maddevsio/mad-radiator/commit/4c47d6ef09e9675d50f3a012e20dfe48648db868)
[Change package version.](https://github.com/maddevsio/mad-radiator/commit/90614829d5022a0ad56f63d9f30b5c213d80d621)